### PR TITLE
Make the iOS statusbar show up in black text

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ WebApp and to the WeVoteCordova, and to the WeVoteCordovaSaveoff (which we will 
      Note: November 18, 2021:  Don't use latest for android for now, so we use version 9 instead of version 10
 
      ```
-     cordova platform add ios@latest android
+     cordova platform add ios android
      ```
      Which runs in the terminal like this...
      ```
@@ -215,7 +215,7 @@ WebApp and to the WeVoteCordova, and to the WeVoteCordovaSaveoff (which we will 
      Installing "cordova-support-google-services" for ios
      Installing "cordova.plugins.diagnostic" for ios
      Dependent plugin "es6-promise-plugin" already installed on ios.
-     Using cordova-fetch for cordova-android@latest
+     Using cordova-fetch for cordova-android
      Adding android project...
      Creating Cordova project for the Android platform:
              Path: platforms/android
@@ -919,7 +919,7 @@ And it should show up running in a container on the desktop (like a native app, 
 
 ### Maybe you have to do this again (try running the app first) 
 stevepodellsilicon@Steves-arm64-Mac WeVoteCordova % cordova platforms remove ios android
-stevepodellsilicon@Steves-arm64-Mac WeVoteCordova % cordova platform add ios@latest android@latest
+stevepodellsilicon@Steves-arm64-Mac WeVoteCordova % cordova platform add ios android
 stevepodellsilicon@Steves-arm64-Mac WeVoteCordova % node buildSymLinks /Users/stevepodellsilicon/WebstormProjects/WebApp/build
 
 ## Insufficient Storage warning on Android Simulator

--- a/buildSymLinks.js
+++ b/buildSymLinks.js
@@ -164,8 +164,39 @@ const updateCordovaLibBuildGradle = () => {
       newGradle.forEach((txt) => {
         fs.writeSync(buildGradle, `${txt}\n`);
       });
-      console.log(`updateCordovaLibBuildGradle hardcoded some android versions in  ${originalFile}`);
-      updateAppBuildGradle();
+    });
+  });
+};
+
+// /Users/stevepodell/WebstormProjects/WeVoteCordova/platforms/android/cdv-gradle-config.json
+// This should be solved in a upcoming version of cordova-android with <preference name="GradleVersion" value="7.2.2" />
+const updateCdvGradleConfig = () => {
+  const originalFile = './platforms/android/cdv-gradle-config.json';
+  const saveOffFile = originalFile + '.previous'
+  console.log(`Processing ${originalFile}`);
+  fs.rename(originalFile, saveOffFile, () => {
+    const rl = readline.createInterface({
+      input: fs.createReadStream(saveOffFile),
+      crlfDelay: Infinity,
+    });
+    const newGradle = [];
+    rl.on('line', (line) => {
+      if (line.includes('AGP_VERSION')) {
+        newGradle.push('  "AGP_VERSION": "7.2.2",');
+        console.log('hardcoding::: AGP_VERSION ::: to 7.2.2 in android/cdv-gradle-config.json');
+      } else if (line.includes('MIN_SDK_VERSION')) {
+        newGradle.push('  "MIN_SDK_VERSION": 16,');
+        console.log('hardcoding::: MIN_SDK_VERSION ::: to 16 in android/cdv-gradle-config.json');
+      } else {
+        newGradle.push(line);
+      }
+    });
+    rl.on('close', () => {
+      const buildGradle = fs.openSync(originalFile, 'w');
+
+      newGradle.forEach((txt) => {
+        fs.writeSync(buildGradle, `${txt}\n`);
+      });
     });
   });
 };
@@ -315,6 +346,7 @@ setTimeout( () => {
   //   err => console.log(err ? err : 'cp android google-services.json successful'));
 
   updateGradleProperties();
+  updateCdvGradleConfig();
   updateMainAndroidManifest();
 
   fs.readdir(iosDir, function(err, items) {

--- a/config.xml
+++ b/config.xml
@@ -45,7 +45,6 @@
     <allow-intent href="*://*.googleapis.com/*" />
 
     <allow-intent href="*" />
-    <!-- A wildcard can be used to whitelist the entire network, over HTTP and HTTPS. *NOT RECOMMENDED* -->
     <allow-navigation href="*" />
     <preference name="AllowedSchemes" value="mycoolapp,wevotetwitterscheme" />
     <platform name="android">
@@ -55,12 +54,9 @@
         <preference name="android-manifest/@android:versionName" value="2.3.0" />
         <preference name="GradlePluginGoogleServicesEnabled" value="true" />
         <preference name="GradlePluginGoogleServicesVersion" value="4.3.13" />
+        <preference name="GradleVersion" value="7.2.2" />
         <resource-file src="res/google/google-services.json" target="app/google-services.json" />
         <allow-intent href="market:*" />
-        <!-- 11/19/21:  If you get too many "E/chromium: [ERROR:tile_manager.cc(793)] WARNING: tile memory limits exceeded, some content may not draw"
-                        errors, Android basically hangs.  Make sure that each splash size matches.  If you remove cordova-plugin-splashscreen, all these errors go away.
-                        I think it has to do with relying on the platform to resize an ill-fitting splash screen.
-                        https://cordova.apache.org/docs/en/10.x/reference/cordova-plugin-splashscreen/index.html#platform-splash-screen-image-configuration-->
         <splash density="ldpi" src="res/screen/android/screen-ldpi-landscape.png" />
         <splash density="mdpi" src="res/screen/android/screen-mdpi-landscape.png" />
         <splash density="hdpi" src="res/screen/android/screen-hdpi-landscape.png" />
@@ -88,11 +84,6 @@
         <feature name="SocialSharing">
             <param name="android-package" value="nl.xservices.plugins.SocialSharing" />
         </feature>
-        <!-- https://github.com/EddyVerbruggen/SocialSharing-PhoneGap-Plugin/issues/1150 -->
-<!--        Removed 8/23/22 with "GloriaTM commented on May 1" substitute approach from the issue above-->
-<!--        <config-file parent="/manifest" target="AndroidManifest.xml" xmlns:android="http://schemas.android.com/apk/res/android">-->
-<!--            <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />-->
-<!--        </config-file>-->
         <config-file parent="/manifest" target="AndroidManifest.xml">
             <queries>
                 <intent>
@@ -102,12 +93,6 @@
             </queries>
         </config-file>
         <preference name="defaultBuildToolsVersion" value="30.0.3" />
-        <!-- these are set in the gradle.properties set by $GRADLE_USER_HOME -->
-        <!-- <preference name="android-useAndroidX" value="true" />-->
-        <!--  11/19/2021: These next two sdk variables are ignored by cordova-android-when we choose to upgrade to version 10 -->
-<!--        <preference name="android-minSdkVersion" value="16" />-->
-<!--        <preference name="android-targetSdkVersion" value="31" /> &ndash;&gt;-->
-
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*" />
@@ -130,12 +115,13 @@
         <preference name="PageLength" value="0" />
         <preference name="PaginationBreakingMode" value="page" />
         <preference name="PaginationMode" value="unpaginated" />
-        <preference name="StatusBarOverlaysWebView" value="true" />
-        <preference name="XXXXStatusBarStyle" value="darkcontent" />
         <preference name="SplashScreen" value="screen" />
         <preference name="SplashScreenDelay" value="3000" />
         <preference name="AutoHideSplashScreen" value="false" />
         <preference name="KeyboardDisplayRequiresUserAction" value="false" />
+        <config-file parent="UIStatusBarStyle" platform="ios" target="*-Info.plist">
+            <string>Dark Content</string>
+        </config-file>
         <config-file parent="FacebookAutoLogAppEventsEnabled" target="*-Info.plist">
             <false />
         </config-file>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "cordova-plugin-ionic-keyboard": "2.2.0",
         "cordova-plugin-screensize": "^1.3.1",
         "cordova-plugin-sign-in-with-apple": "0.1.2",
-        "cordova-plugin-statusbar": "^3.0.0",
         "cordova-plugin-taptic-engine": "^2.2.0",
         "cordova-plugin-whitelist": "^1.3.5",
         "cordova-support-android-plugin": "2.0.3",
@@ -26,7 +25,6 @@
       },
       "devDependencies": {
         "cordova-android": "^10.1.2",
-        "cordova-ios": "^6.2.0",
         "cordova-plugin-add-swift-support": "^2.0.2",
         "cordova-plugin-contacts-x": "^2.0.3",
         "cordova-plugin-customurlscheme": "github:EddyVerbruggen/Custom-URL-scheme",
@@ -288,42 +286,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cordova-ios": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-6.2.0.tgz",
-      "integrity": "sha512-sLjZg2QBI1SpQVwfe0MSn89YNVkBGLW9Q1vcFJBsqKBrhvoEOJ5Ytq0gwqdhgTOGzlwJUfxC6OHM3jcsRjtYrw==",
-      "dev": true,
-      "dependencies": {
-        "cordova-common": "^4.0.2",
-        "fs-extra": "^9.1.0",
-        "ios-sim": "^8.0.2",
-        "nopt": "^5.0.0",
-        "plist": "^3.0.1",
-        "semver": "^7.3.4",
-        "unorm": "^1.6.0",
-        "which": "^2.0.2",
-        "xcode": "^3.0.1",
-        "xml-escape": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cordova-ios/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cordova-plugin-add-swift-support": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-add-swift-support/-/cordova-plugin-add-swift-support-2.0.2.tgz",
@@ -495,21 +457,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-sign-in-with-apple/-/cordova-plugin-sign-in-with-apple-0.1.2.tgz",
       "integrity": "sha512-SOVa2fwqT5aRGCclgjQIZAA0RsylX9vWtVwNK9sx6kTV65FjZ2CcOygyY//EIo9YNSGzHR+OExhu9EDagyZIpg=="
-    },
-    "node_modules/cordova-plugin-statusbar": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-3.0.0.tgz",
-      "integrity": "sha512-nzkeWeyLA6+1FryzO0aeB6NS8MZ45gnBYeq2VZqfdNbddZEgtpI4XPYdBVxvm9NhcVoJ3tdA1OBnQD9JryoV0Q==",
-      "engines": {
-        "cordovaDependencies": {
-          "0.1.0": {
-            "cordova": ">=3.0.0"
-          },
-          "4.0.0": {
-            "cordova": ">100"
-          }
-        }
-      }
     },
     "node_modules/cordova-plugin-taptic-engine": {
       "version": "2.2.0",
@@ -708,12 +655,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -764,18 +705,6 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -800,66 +729,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/ios-sim": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/ios-sim/-/ios-sim-8.0.2.tgz",
-      "integrity": "sha512-P7nEG771bfd+JoMRjnis1gpZOkjTUUxu+4Ek1Z+eoaEEoT9byllU9pxfQ8Df7hL3gSkIQxNwTSLhos2I8tWUQA==",
-      "dev": true,
-      "dependencies": {
-        "bplist-parser": "^0.0.6",
-        "nopt": "1.0.9",
-        "plist": "^3.0.1",
-        "simctl": "^2"
-      },
-      "bin": {
-        "ios-sim": "bin/ios-sim"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ios-sim/node_modules/bplist-parser": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
-      "integrity": "sha512-fGeghPEH4Eytvf+Mi446aKcDqvkA/+eh6r7QGiZWMQG6TzqrnsToLP379XFfqRSZ41+676hhGIm++maNST1Apw==",
-      "dev": true
-    },
-    "node_modules/ios-sim/node_modules/nopt": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.9.tgz",
-      "integrity": "sha512-CmUZ3rzN0/4kRHum5pGRiGkhmBMzgtEDxrZVHqRJDSv8qK6s+wzaig/xeyB22Due5aZQeTiEZg/nrmMH2tapDQ==",
-      "dev": true,
-      "dependencies": {
-        "abbrev": "1"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "dev": true,
-      "dependencies": {
-        "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1113,12 +982,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1206,35 +1069,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "dependencies": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/reusify": {
@@ -1326,38 +1160,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "node_modules/simctl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/simctl/-/simctl-2.0.3.tgz",
-      "integrity": "sha512-kKCak0yszxHae5eVWcmrjV3ouUGac3sjlhjdLWpyPu4eiQcWoHsCrqS34kkgzHN8Ystqkh/LFjzrldk/g3BYJg==",
-      "dev": true,
-      "dependencies": {
-        "shelljs": "^0.8.5",
-        "tail": "^0.4.0"
-      }
     },
     "node_modules/simple-plist": {
       "version": "1.3.1",
@@ -1415,27 +1222,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tail": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tail/-/tail-0.4.0.tgz",
-      "integrity": "sha512-i5rOhX0PwkFSbjID14mmuoqrLUIqpJeBwg0esugSbb+6Y+dzgN/O3YZXzzPL7dnQJGbQLs8cwM8Zsak5kFJGcA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1463,15 +1249,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -1479,15 +1256,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -1523,25 +1291,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "node_modules/xcode": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-      "dev": true,
-      "dependencies": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xml-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
-      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
       "dev": true
     },
     "node_modules/xmlbuilder": {
@@ -1760,38 +1509,6 @@
         }
       }
     },
-    "cordova-ios": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-6.2.0.tgz",
-      "integrity": "sha512-sLjZg2QBI1SpQVwfe0MSn89YNVkBGLW9Q1vcFJBsqKBrhvoEOJ5Ytq0gwqdhgTOGzlwJUfxC6OHM3jcsRjtYrw==",
-      "dev": true,
-      "requires": {
-        "cordova-common": "^4.0.2",
-        "fs-extra": "^9.1.0",
-        "ios-sim": "^8.0.2",
-        "nopt": "^5.0.0",
-        "plist": "^3.0.1",
-        "semver": "^7.3.4",
-        "unorm": "^1.6.0",
-        "which": "^2.0.2",
-        "xcode": "^3.0.1",
-        "xml-escape": "^1.1.0"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        }
-      }
-    },
     "cordova-plugin-add-swift-support": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-add-swift-support/-/cordova-plugin-add-swift-support-2.0.2.tgz",
@@ -1894,11 +1611,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/cordova-plugin-sign-in-with-apple/-/cordova-plugin-sign-in-with-apple-0.1.2.tgz",
       "integrity": "sha512-SOVa2fwqT5aRGCclgjQIZAA0RsylX9vWtVwNK9sx6kTV65FjZ2CcOygyY//EIo9YNSGzHR+OExhu9EDagyZIpg=="
-    },
-    "cordova-plugin-statusbar": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cordova-plugin-statusbar/-/cordova-plugin-statusbar-3.0.0.tgz",
-      "integrity": "sha512-nzkeWeyLA6+1FryzO0aeB6NS8MZ45gnBYeq2VZqfdNbddZEgtpI4XPYdBVxvm9NhcVoJ3tdA1OBnQD9JryoV0Q=="
     },
     "cordova-plugin-taptic-engine": {
       "version": "2.2.0",
@@ -2049,12 +1761,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -2090,15 +1796,6 @@
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -2120,50 +1817,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
-    },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
-    },
-    "ios-sim": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/ios-sim/-/ios-sim-8.0.2.tgz",
-      "integrity": "sha512-P7nEG771bfd+JoMRjnis1gpZOkjTUUxu+4Ek1Z+eoaEEoT9byllU9pxfQ8Df7hL3gSkIQxNwTSLhos2I8tWUQA==",
-      "dev": true,
-      "requires": {
-        "bplist-parser": "^0.0.6",
-        "nopt": "1.0.9",
-        "plist": "^3.0.1",
-        "simctl": "^2"
-      },
-      "dependencies": {
-        "bplist-parser": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
-          "integrity": "sha512-fGeghPEH4Eytvf+Mi446aKcDqvkA/+eh6r7QGiZWMQG6TzqrnsToLP379XFfqRSZ41+676hhGIm++maNST1Apw==",
-          "dev": true
-        },
-        "nopt": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.9.tgz",
-          "integrity": "sha512-CmUZ3rzN0/4kRHum5pGRiGkhmBMzgtEDxrZVHqRJDSv8qK6s+wzaig/xeyB22Due5aZQeTiEZg/nrmMH2tapDQ==",
-          "dev": true,
-          "requires": {
-            "abbrev": "1"
-          }
-        }
-      }
-    },
-    "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -2347,12 +2000,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -2404,26 +2051,6 @@
       "requires": {
         "pify": "^4.0.1",
         "with-open-file": "^0.1.6"
-      }
-    },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
-    "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.9.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
     "reusify": {
@@ -2479,32 +2106,11 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
-    },
-    "simctl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/simctl/-/simctl-2.0.3.tgz",
-      "integrity": "sha512-kKCak0yszxHae5eVWcmrjV3ouUGac3sjlhjdLWpyPu4eiQcWoHsCrqS34kkgzHN8Ystqkh/LFjzrldk/g3BYJg==",
-      "dev": true,
-      "requires": {
-        "shelljs": "^0.8.5",
-        "tail": "^0.4.0"
-      }
     },
     "simple-plist": {
       "version": "1.3.1",
@@ -2552,18 +2158,6 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
-    },
-    "tail": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/tail/-/tail-0.4.0.tgz",
-      "integrity": "sha512-i5rOhX0PwkFSbjID14mmuoqrLUIqpJeBwg0esugSbb+6Y+dzgN/O3YZXzzPL7dnQJGbQLs8cwM8Zsak5kFJGcA==",
-      "dev": true
-    },
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2585,22 +2179,10 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
-    "unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "dev": true
-    },
     "untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
       "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "dev": true
-    },
-    "uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
       "dev": true
     },
     "which": {
@@ -2627,22 +2209,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "xcode": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
-      "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
-      "dev": true,
-      "requires": {
-        "simple-plist": "^1.1.0",
-        "uuid": "^7.0.3"
-      }
-    },
-    "xml-escape": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
-      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
       "dev": true
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "license": "MIT",
   "devDependencies": {
     "cordova-android": "^10.1.2",
-    "cordova-ios": "^6.2.0",
     "cordova-plugin-add-swift-support": "^2.0.2",
     "cordova-plugin-contacts-x": "^2.0.3",
     "cordova-plugin-customurlscheme": "github:EddyVerbruggen/Custom-URL-scheme",
@@ -51,7 +50,6 @@
       "cordova-plugin-safariviewcontroller": {},
       "cordova-plugin-screensize": {},
       "cordova-plugin-sign-in-with-apple": {},
-      "cordova-plugin-statusbar": {},
       "cordova-plugin-taptic-engine": {},
       "cordova-plugin-whitelist": {},
       "cordova-plugin-x-socialsharing": {
@@ -87,7 +85,6 @@
     "cordova-plugin-ionic-keyboard": "2.2.0",
     "cordova-plugin-screensize": "^1.3.1",
     "cordova-plugin-sign-in-with-apple": "0.1.2",
-    "cordova-plugin-statusbar": "^3.0.0",
     "cordova-plugin-taptic-engine": "^2.2.0",
     "cordova-plugin-whitelist": "^1.3.5",
     "cordova-support-android-plugin": "2.0.3",

--- a/www/index.html
+++ b/www/index.html
@@ -67,13 +67,11 @@
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="viewport" content="initial-scale=1, width=device-width, viewport-fit=cover">
     <!-- Feb 2018 WeVote: re 'viewport-fit=cover' see https://issues.apache.org/jira/browse/CB-12886 -->
-<!--    <link rel="stylesheet" type="text/css" href="css/index.css">-->
     <link href="https://use.fontawesome.com/releases/v5.8.2/css/all.css" integrity="sha384-oS3vJWv+0UjzBfQzYUhtDYW+Pj2yciDJxpsK1OYPAYjqT085Qq/1cq5FLXAZQ7Ay" crossOrigin="anonymous" rel="stylesheet" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-social/4.12.0/bootstrap-social.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick-theme.min.css" />
-<!--    <link rel="stylesheet" type="text/css" href="css/bootstrap.css" />-->
     <link rel="stylesheet" type="text/css" href="css/main.css" />
     <title>We Vote</title>
 </head>


### PR DESCRIPTION
Removed cordova-plugin-statusbar since it couldn’t handle setting for ‘Dark Content’, instead set ‘Dark Content’ via the ios Info.plist with a change to WeVoteCordova’s config.xml.
Sets AGP - android gradle plugin - version to 7.2.2 so we don't have to upgrade, everytime we load the Android Studio app.