### PR TITLE
Cordova changes for iOS and Android build 2.7.3 step 14

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <widget
-        android-versionCode="2070312"
+        android-versionCode="2070314"
         id="org.wevote.cordova"
         namespace="org.wevote.cordova"
-        ios-CFBundleVersion="2.7.3.12"
+        ios-CFBundleVersion="2.7.3.14"
         version="2.7.3"
         xmlns:android="http://schemas.android.com/apk/res/android">
         xmlns="http://www.w3.org/ns/widgets"
@@ -89,7 +89,7 @@
             <string>We Vote</string>
         </edit-config>
         <edit-config file="*-Info.plist" mode="merge" target="CFBundleVersion">
-            <string>2.7.3.12</string>
+            <string>2.7.3.14</string>
         </edit-config>
         <edit-config file="*-Info.plist" mode="merge" target="CFBundleShortVersionString">
             <string>2.7.3</string>


### PR DESCRIPTION
Previously called step 15, but that was never published. 
"2.7.3.14" was submitted to the Google Play Store on 10/8/25 at about 10:15am 
Needed for https://github.com/wevote/WebApp/pull/4555 
Fixes https://wevoteusa.atlassian.net/issues/?filter=10941&selectedIssue=WV-299